### PR TITLE
bugfix/accurics_remediation_15567846701594035 - Auto Generated Pull Request From Accurics

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -14,3 +14,57 @@ resource "aws_vpc" "aws-demo" {
     "Estimated Expiry" = "2-11-2023"
   }
 }
+
+resource "aws_flow_log" "vpc-01bf637028c50db1f" {
+  vpc_id          = "${aws_vpc.vpc-01bf637028c50db1f.id}"
+  iam_role_arn    = "<iam_role_arn>"
+  log_destination = "${aws_s3_bucket.vpc-01bf637028c50db1f.arn}"
+  traffic_type    = "ALL"
+
+  tags = {
+    GeneratedBy      = "Accurics"
+    ParentResourceId = "aws_vpc.vpc-01bf637028c50db1f"
+  }
+}
+resource "aws_s3_bucket" "vpc-01bf637028c50db1f" {
+  bucket        = "vpc-01bf637028c50db1f_flow_log_s3_bucket"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+resource "aws_s3_bucket_policy" "vpc-01bf637028c50db1f" {
+  bucket = "${aws_s3_bucket.vpc-01bf637028c50db1f.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "vpc-01bf637028c50db1f-restrict-access-to-users-or-roles",
+      "Effect": "Allow",
+      "Principal": [
+        {
+          "AWS": [
+            <principal_arn>
+          ]
+        }
+      ],
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.vpc-01bf637028c50db1f.id}/*"
+    }
+  ]
+}
+POLICY
+}


### PR DESCRIPTION
Perform the following to determine if VPC Flow logs is enabled:

**From Console:**

1. Sign into the management console
2. Select `Services` then `VPC` 
3. In the left navigation pane, select `Your VPCs` 
4. Select a VPC
5. In the right pane, select the `Flow Logs` tab.
6. If no Flow Log exists, click `Create Flow Log` 
7. For Filter, select `Reject`
8. Enter in a `Role` and `Destination Log Group` 
9. Click `Create Log Flow` 
10. Click on `CloudWatch Logs Group` 

**Note:** Setting the filter to "Reject" will dramatically reduce the logging data accumulation for this recommendation and provide sufficient information for the purposes of breach detection, research and remediation. However, during periods of least privilege security group engineering, setting this the filter to "All" can be very helpful in discovering existing traffic flows required for proper operation of an already running environment.